### PR TITLE
Update the link name for about to about us

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -14,7 +14,7 @@
             <%= link_to "Home", root_path, class: "nav-link" %>
           </li>
           <li class="nav-item">
-            <%= link_to "About", about_path, class: "nav-link" %>
+            <%= link_to "About us", about_path, class: "nav-link" %>
           </li>
         <% if user_signed_in? %>
           <li class="nav-item">


### PR DESCRIPTION
About was changed for About us because it is more descriptive